### PR TITLE
doc: show faucet links when on testnet

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -37,16 +37,44 @@
         /></a>
         <h1>RPC Explorer</h1>
         <ul>
+          <li data-network="testnet" hidden>
+            <a
+              href="http://faucet.test.dash.crowdnode.io/"
+              target="_blank"
+              title="CrowdNode Faucet"
+              >CN 💸</a
+            >
+          </li>
+          <li data-network="testnet" hidden>
+            <a
+              href="http://faucet.test.dash.crowdnode.io/"
+              target="_blank"
+              title="Dash Core Group Faucet"
+              >DCG 💸</a
+            >
+          </li>
           <li>
-            <a href="https://github.com/digitalcashdev/rpcproxy" target="_blank"
-              >Git Source ↗</a
+            <a
+              href="https://github.com/digitalcashdev/rpcproxy/issues"
+              target="_blank"
+              title="Git Issues"
+              >Bugs 🐛</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://github.com/digitalcashdev/rpcproxy"
+              target="_blank"
+              title="Git Source"
+              >Git 📦</a
             >
           </li>
           <li>
             <a
               href="https://docs.dash.org/projects/core/en/stable/docs/api/remote-procedure-call-quick-reference.html"
               target="_blank"
-              >DCG Docs ↗</a
+              title="Dash Core Group Docs"
+              >DCG 📚</a
             >
           </li>
         </ul>
@@ -367,6 +395,12 @@ return data.result;
           }
           $network.innerText = network;
 
+          if (network === "testnet") {
+            let $testnets = document.querySelectorAll("[data-network=testnet]");
+            for ($testnet of $testnets) {
+              $testnet.removeAttribute("hidden");
+            }
+          }
           document.body.removeAttribute("hidden");
         }
 

--- a/static/index.html
+++ b/static/index.html
@@ -13,6 +13,9 @@
         padding-top: 0;
         padding-bottom: 0.3rem;
       }
+      header nav img {
+        margin: 0;
+      }
       main {
         padding-top: 0;
       }
@@ -20,8 +23,13 @@
         width: 100%;
         box-sizing: border-box;
       }
-      hr {
-        margin-top: 1.2em;
+      hr,
+      footer hr {
+        margin-top: 1.2rem;
+        margin-bottom: 1.2rem;
+      }
+      footer {
+        padding: 1rem; 1rem;
       }
     </style>
   </head>

--- a/static/index.html
+++ b/static/index.html
@@ -83,13 +83,13 @@
     <main>
       <section>
         <form id="rpc-form" onsubmit="submitForm(event)">
-          <label
+          <label data-network="testnet" hidden
             >Network
-            <small
-              ><code data-id="network"
-                >&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code
-              ></small
-            >
+            <!-- <input type="text" data-id="network" disabled /> -->
+            <br />
+            <pre
+              style="margin: 0; padding: 0"
+            ><code data-id="network" disabled>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code></pre>
           </label>
           <label
             >Method <small>name (string)</small>
@@ -394,6 +394,7 @@ return data.result;
             network = "mainnet";
           }
           $network.innerText = network;
+          $network.value = network;
 
           if (network === "testnet") {
             let $testnets = document.querySelectorAll("[data-network=testnet]");


### PR DESCRIPTION
- use descriptive emojis to shorten links
- add faucet links when on testnet
- less padding / margin in header / footer

<img width="815" alt="Screenshot 2024-08-10 at 3 20 47 AM" src="https://github.com/user-attachments/assets/1b0937a7-e80c-482d-9944-8111495661a9">

<img width="815" alt="Screenshot 2024-08-10 at 5 21 23 AM" src="https://github.com/user-attachments/assets/b2860c24-85db-411c-b2a6-f7001cae49f4">
