### PR TITLE
feat: add `getislocks` and various `quorum` subcommands

### DIFF
--- a/static/public-rpcs.json
+++ b/static/public-rpcs.json
@@ -59,7 +59,20 @@
         "// Evolution RPCs": [{ "-": [] }],
         "bls": [],
         "//protx": [{ "-": [] }],
-        "//quorum": [{ "-": [] }],
+        "quorum": [
+            {
+                "list": [],
+                "info": [],
+                "dkgstatus": [],
+                "getdata": [],
+                "getrecsig": [],
+                "listextended": [],
+                "rotationinfo": [],
+                "verify": []
+            }
+        ],
+        "//quorum[regtest].hashrecsigsign,isconflicting": [],
+        "//quorum[masternode].sign,memberof,platformsign,selectquorum": [],
         "verifychainlock": [],
         "verifyislock": [],
         "// Generating RPCs": [{ "-": [] }],

--- a/static/public-rpcs.json
+++ b/static/public-rpcs.json
@@ -68,6 +68,7 @@
         "// Raw Transaction RPCs": [{ "-": [] }],
         "decoderawtransaction": [],
         "decodescript": [],
+        "getislocks": [],
         "getrawtransaction": [],
         "getrawtransactionmulti": [],
         "gettxchainlocks": [],


### PR DESCRIPTION
The diff is the simplest explanation:

```diff
diff --git a/static/public-rpcs.json b/static/public-rpcs.json
index aae17d9..8d7c5ef 100644
--- a/static/public-rpcs.json
+++ b/static/public-rpcs.json
@@ -59,7 +59,20 @@
         "// Evolution RPCs": [{ "-": [] }],
         "bls": [],
         "//protx": [{ "-": [] }],
-        "//quorum": [{ "-": [] }],
+        "quorum": [
+            {
+                "list": [],
+                "info": [],
+                "dkgstatus": [],
+                "getdata": [],
+                "getrecsig": [],
+                "listextended": [],
+                "rotationinfo": [],
+                "verify": []
+            }
+        ],
+        "//quorum[regtest].hashrecsigsign,isconflicting": [],
+        "//quorum[masternode].sign,memberof,platformsign,selectquorum": [],
         "verifychainlock": [],
         "verifyislock": [],
         "// Generating RPCs": [{ "-": [] }],
@@ -68,6 +81,7 @@
         "// Raw Transaction RPCs": [{ "-": [] }],
         "decoderawtransaction": [],
         "decodescript": [],
+        "getislocks": [],
         "getrawtransaction": [],
         "getrawtransactionmulti": [],
         "gettxchainlocks": [],
```

De-listed the regtest- and masternode-only RPCs.